### PR TITLE
Initialize project structure for pdfqanda

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,64 @@
 # pdfqanda
+
+pdfqanda is a lightweight retrieval-based assistant that lets you ask questions about the
+contents of your local PDF documents. The project provides a small set of utilities to extract
+text, break it into overlapping chunks, index those chunks with a TF-IDF vector store, and query
+for the most relevant excerpts. The PDF extractor focuses on simple text-based PDFs by scanning
+their content streams and may not work for heavily compressed or scanned documents.
+
+## Features
+
+- Extract text from one or more PDF files using a lightweight parser for text-based PDFs.
+- Split long documents into overlapping text chunks for improved retrieval.
+- Index text chunks with a TF-IDF vectorizer and cosine similarity search.
+- Command line interface for building indexes and asking questions.
+- Optional JSON export of retrieved answers for downstream automation.
+
+## Getting Started
+
+### Prerequisites
+
+- Python 3.10 or newer.
+
+### Installation
+
+```bash
+pip install -e .[dev]
+```
+
+### Building an Index
+
+```bash
+pdfqanda build path/to/document.pdf path/to/another.pdf --output my-index.pkl
+```
+
+### Asking a Question
+
+```bash
+pdfqanda ask --index my-index.pkl "What is the main conclusion?"
+```
+
+Answers are displayed in a table sorted by cosine similarity score. You can also export the
+results to JSON:
+
+```bash
+pdfqanda ask --index my-index.pkl "Summarize section 3" --json-output answers.json
+```
+
+## Development
+
+### Running Tests
+
+```bash
+pytest
+```
+
+### Linting
+
+```bash
+ruff check .
+```
+
+## License
+
+This project is licensed under the terms of the MIT License. See [LICENSE](LICENSE) for details.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,32 @@
+[project]
+name = "pdfqanda"
+version = "0.1.0"
+description = "Simple question answering assistant for local PDF documents"
+authors = [{name = "Your Name"}]
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+  "typer>=0.9.0",
+  "rich>=13.0.0"
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=7.4",
+  "ruff>=0.4.0"
+]
+
+[project.scripts]
+pdfqanda = "pdfqanda.cli:app"
+
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+addopts = "-ra"
+pythonpath = ["src"]
+
+[tool.ruff]
+line-length = 100
+

--- a/src/pdfqanda/__init__.py
+++ b/src/pdfqanda/__init__.py
@@ -1,0 +1,5 @@
+"""pdfqanda package initialization."""
+
+from .qa import PdfQaEngine
+
+__all__ = ["PdfQaEngine"]

--- a/src/pdfqanda/cli.py
+++ b/src/pdfqanda/cli.py
@@ -1,0 +1,69 @@
+"""Command line interface for pdfqanda."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from .qa import PdfQaEngine
+
+app = typer.Typer(help="Build and query lightweight QA indexes for PDF documents.")
+console = Console()
+
+
+@app.command()
+def build(
+    pdfs: list[Path] = typer.Argument(..., help="One or more PDF files to index."),
+    output: Path = typer.Option("index.pkl", help="Path to save the generated index."),
+    chunk_size: int = typer.Option(1000, help="Chunk size in characters."),
+    overlap: int = typer.Option(200, help="Overlap size between chunks."),
+) -> None:
+    """Build a TF-IDF index from the provided PDFs."""
+
+    engine = PdfQaEngine(chunk_size=chunk_size, overlap=overlap)
+    console.print("[bold green]Building index...[/bold green]")
+    engine.build_index(pdfs)
+    engine.save(output)
+    console.print(f"Index saved to [bold]{output}[/bold]")
+
+
+@app.command()
+def ask(
+    index_path: Path = typer.Option(..., "--index", "-i", help="Path to a saved index."),
+    question: str = typer.Argument(..., help="Question to ask about the indexed PDFs."),
+    top_k: int = typer.Option(3, help="Number of answers to return."),
+    json_output: Optional[Path] = typer.Option(None, help="Optional path to export answers as JSON."),
+) -> None:
+    """Ask a question about the indexed PDFs."""
+
+    engine = PdfQaEngine.load(index_path)
+    engine.top_k = top_k
+    answers = engine.query(question)
+
+    if not answers:
+        console.print("[bold yellow]No answers found.[/bold yellow]")
+        raise typer.Exit(code=1)
+
+    table = Table(title="Top Answers")
+    table.add_column("Rank", justify="right")
+    table.add_column("Score", justify="right")
+    table.add_column("Excerpt", overflow="fold")
+
+    for i, answer in enumerate(answers, start=1):
+        table.add_row(str(i), f"{answer.score:.3f}", answer.text)
+
+    console.print(table)
+
+    if json_output:
+        payload = [answer.__dict__ for answer in answers]
+        json_output.write_text(json.dumps(payload, indent=2))
+        console.print(f"Answers saved to [bold]{json_output}[/bold]")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    app()

--- a/src/pdfqanda/ingest.py
+++ b/src/pdfqanda/ingest.py
@@ -1,0 +1,44 @@
+"""Utilities for loading text from PDF documents."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Iterable
+
+_STREAM_PATTERN = re.compile(rb"stream(.*?)endstream", re.DOTALL)
+_TEXT_PATTERN = re.compile(rb"\((.*?)\)")
+
+
+def _decode_pdf_text(data: bytes) -> str:
+    text = data.decode("latin1")
+    text = text.replace("\\r", "\r").replace("\\n", "\n").replace("\\t", "\t")
+    text = text.replace("\\(", "(").replace("\\)", ")").replace("\\\\", "\\")
+    return text
+
+
+def extract_text_from_pdf(path: str | Path) -> str:
+    """Extract text content from a PDF file by scanning content streams."""
+
+    pdf_path = Path(path)
+    if not pdf_path.exists():
+        msg = f"PDF file does not exist: {pdf_path}"
+        raise FileNotFoundError(msg)
+
+    data = pdf_path.read_bytes()
+    text_fragments: list[str] = []
+    for stream_match in _STREAM_PATTERN.finditer(data):
+        stream_data = stream_match.group(1)
+        for text_match in _TEXT_PATTERN.finditer(stream_data):
+            text_fragments.append(_decode_pdf_text(text_match.group(1)))
+
+    return "\n".join(fragment.strip() for fragment in text_fragments if fragment.strip())
+
+
+def load_documents(paths: Iterable[str | Path]) -> str:
+    """Load and concatenate text from multiple PDF documents."""
+
+    contents: list[str] = []
+    for path in paths:
+        contents.append(extract_text_from_pdf(path))
+    return "\n\n".join(filter(None, contents))

--- a/src/pdfqanda/qa.py
+++ b/src/pdfqanda/qa.py
@@ -1,0 +1,101 @@
+"""High-level interface for building and querying PDF Q&A indexes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+from .ingest import extract_text_from_pdf, load_documents
+from .splitter import TextSplitter
+from .vectorstore import TfidfVectorStore, VectorStoreResult
+
+
+@dataclass
+class Answer:
+    """Answer returned by the QA engine."""
+
+    text: str
+    score: float
+    source_index: int
+    start_char: int
+    end_char: int
+
+
+class PdfQaEngine:
+    """Build a simple retrieval-based Q&A system for PDF documents."""
+
+    def __init__(
+        self,
+        chunk_size: int = 1000,
+        overlap: int = 200,
+        top_k: int = 3,
+    ) -> None:
+        self.splitter = TextSplitter(chunk_size=chunk_size, overlap=overlap)
+        self.top_k = top_k
+        self.store = TfidfVectorStore()
+
+    def build_index(self, pdf_paths: Iterable[str | Path]) -> None:
+        """Load PDFs and build the TF-IDF index."""
+
+        combined_text = load_documents(pdf_paths)
+        chunks = self.splitter.split_text(combined_text)
+        if not chunks:
+            msg = "No text extracted from provided documents"
+            raise ValueError(msg)
+        self.store.fit(chunks)
+
+    def query(self, question: str) -> list[Answer]:
+        results = self.store.query(question, top_k=self.top_k)
+        return [
+            Answer(
+                text=result.chunk.content.strip(),
+                score=result.score,
+                source_index=result.chunk.index,
+                start_char=result.chunk.start_char,
+                end_char=result.chunk.end_char,
+            )
+            for result in results
+        ]
+
+    def save(self, path: str | Path) -> None:
+        self.store.save(path)
+
+    @classmethod
+    def load(cls, path: str | Path) -> "PdfQaEngine":
+        engine = cls()
+        engine.store = TfidfVectorStore.load(path)
+        return engine
+
+    def build_index_with_progress(self, pdf_paths: Iterable[str | Path]) -> None:
+        """Build index while displaying a progress bar."""
+
+        pdf_paths = list(pdf_paths)
+        combined_texts = []
+        total = len(pdf_paths)
+        for idx, pdf_path in enumerate(pdf_paths, start=1):
+            combined_texts.append(extract_text_from_pdf(pdf_path))
+            print(f"Reading PDFs: {idx}/{total}", end="\r", flush=True)
+        print()
+        combined_text = "\n\n".join(filter(None, combined_texts))
+        chunks = self.splitter.split_text(combined_text)
+        if not chunks:
+            msg = "No text extracted from provided documents"
+            raise ValueError(msg)
+        self.store.fit(chunks)
+
+    def query_with_sources(self, question: str) -> list[tuple[Answer, VectorStoreResult]]:
+        results = self.store.query(question, top_k=self.top_k)
+        return [
+            (
+                Answer(
+                    text=result.chunk.content.strip(),
+                    score=result.score,
+                    source_index=result.chunk.index,
+                    start_char=result.chunk.start_char,
+                    end_char=result.chunk.end_char,
+                ),
+                result,
+            )
+            for result in results
+        ]

--- a/src/pdfqanda/splitter.py
+++ b/src/pdfqanda/splitter.py
@@ -1,0 +1,48 @@
+"""Simple text chunking utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class TextChunk:
+    """Representation of a chunk of text with metadata."""
+
+    content: str
+    index: int
+    start_char: int
+    end_char: int
+
+
+class TextSplitter:
+    """Split text into overlapping chunks."""
+
+    def __init__(self, chunk_size: int = 1000, overlap: int = 200) -> None:
+        if chunk_size <= 0:
+            msg = "chunk_size must be positive"
+            raise ValueError(msg)
+        if not 0 <= overlap < chunk_size:
+            msg = "overlap must be between 0 and chunk_size"
+            raise ValueError(msg)
+        self.chunk_size = chunk_size
+        self.overlap = overlap
+
+    def split_text(self, text: str) -> list[TextChunk]:
+        """Split text into chunks of approximately ``chunk_size`` characters."""
+
+        chunks: list[TextChunk] = []
+        if not text:
+            return chunks
+
+        start = 0
+        index = 0
+        while start < len(text):
+            end = min(len(text), start + self.chunk_size)
+            chunk_text = text[start:end]
+            chunks.append(TextChunk(content=chunk_text, index=index, start_char=start, end_char=end))
+            index += 1
+            if end == len(text):
+                break
+            start = end - self.overlap
+        return chunks

--- a/src/pdfqanda/vectorstore.py
+++ b/src/pdfqanda/vectorstore.py
@@ -1,0 +1,145 @@
+"""Simple TF-IDF backed vector store for text chunks."""
+
+from __future__ import annotations
+
+import math
+import pickle
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+from .splitter import TextChunk
+
+
+TOKEN_PATTERN = re.compile(r"[A-Za-z0-9_]+")
+
+
+def _tokenize(text: str) -> list[str]:
+    return [token.lower() for token in TOKEN_PATTERN.findall(text)]
+
+
+def _compute_norm(vector: Dict[str, float]) -> float:
+    return math.sqrt(sum(weight * weight for weight in vector.values()))
+
+
+def _cosine_similarity(vec_a: Dict[str, float], vec_b: Dict[str, float]) -> float:
+    if not vec_a or not vec_b:
+        return 0.0
+    if len(vec_a) < len(vec_b):
+        vec_a, vec_b = vec_b, vec_a
+    dot = sum(weight * vec_b.get(term, 0.0) for term, weight in vec_a.items())
+    norm_a = _compute_norm(vec_a)
+    norm_b = _compute_norm(vec_b)
+    if norm_a == 0 or norm_b == 0:
+        return 0.0
+    return dot / (norm_a * norm_b)
+
+
+@dataclass
+class VectorStoreResult:
+    chunk: TextChunk
+    score: float
+
+
+class TfidfVectorStore:
+    """In-memory TF-IDF vector store using a lightweight implementation."""
+
+    def __init__(self) -> None:
+        self._vectors: list[Dict[str, float]] = []
+        self._chunks: list[TextChunk] = []
+        self._idf: Dict[str, float] = {}
+
+    @property
+    def is_fit(self) -> bool:
+        return bool(self._vectors) and bool(self._chunks)
+
+    def fit(self, chunks: Iterable[TextChunk]) -> None:
+        chunk_list = list(chunks)
+        if not chunk_list:
+            msg = "At least one chunk is required to build the index"
+            raise ValueError(msg)
+
+        tokenized: list[List[str]] = [_tokenize(chunk.content) for chunk in chunk_list]
+        document_frequency: Dict[str, int] = {}
+        for tokens in tokenized:
+            seen = set(tokens)
+            for token in seen:
+                document_frequency[token] = document_frequency.get(token, 0) + 1
+
+        total_docs = len(chunk_list)
+        self._idf = {
+            term: math.log((1 + total_docs) / (1 + df)) + 1.0
+            for term, df in document_frequency.items()
+        }
+
+        vectors: list[Dict[str, float]] = []
+        for tokens in tokenized:
+            counts: Dict[str, int] = {}
+            for token in tokens:
+                counts[token] = counts.get(token, 0) + 1
+            length = len(tokens) or 1
+            vector: Dict[str, float] = {}
+            for token, count in counts.items():
+                tf = count / length
+                idf = self._idf.get(token, 0.0)
+                vector[token] = tf * idf
+            vectors.append(vector)
+
+        self._vectors = vectors
+        self._chunks = chunk_list
+
+    def _vectorize_query(self, text: str) -> Dict[str, float]:
+        tokens = _tokenize(text)
+        if not tokens:
+            return {}
+        counts: Dict[str, int] = {}
+        for token in tokens:
+            counts[token] = counts.get(token, 0) + 1
+        length = len(tokens)
+        vector: Dict[str, float] = {}
+        for token, count in counts.items():
+            idf = self._idf.get(token, 0.0)
+            if idf == 0:
+                continue
+            tf = count / length
+            vector[token] = tf * idf
+        return vector
+
+    def query(self, text: str, top_k: int = 3) -> list[VectorStoreResult]:
+        if not self.is_fit:
+            msg = "Vector store must be fit before querying"
+            raise ValueError(msg)
+        if not text:
+            return []
+
+        query_vector = self._vectorize_query(text)
+        scored = [
+            (index, _cosine_similarity(query_vector, vector))
+            for index, vector in enumerate(self._vectors)
+        ]
+        scored.sort(key=lambda item: item[1], reverse=True)
+        top_results = scored[:top_k]
+        return [VectorStoreResult(chunk=self._chunks[index], score=score) for index, score in top_results]
+
+    def save(self, path: str | Path) -> None:
+        if not self.is_fit:
+            msg = "Vector store must be fit before saving"
+            raise ValueError(msg)
+        data = {
+            "vectors": self._vectors,
+            "chunks": self._chunks,
+            "idf": self._idf,
+        }
+        with Path(path).open("wb") as file:
+            pickle.dump(data, file)
+
+    @classmethod
+    def load(cls, path: str | Path) -> "TfidfVectorStore":
+        with Path(path).open("rb") as file:
+            data = pickle.load(file)
+        store = cls()
+        store._vectors = data["vectors"]
+        store._chunks = data["chunks"]
+        store._idf = data["idf"]
+        return store

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+from pdfqanda.ingest import extract_text_from_pdf
+
+SAMPLE_PDF = b"""%PDF-1.4\n1 0 obj<< /Type /Catalog /Pages 2 0 R>>endobj\n2 0 obj<< /Type /Pages /Kids [3 0 R] /Count 1>>endobj\n3 0 obj<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R /Resources<< /Font<< /F1 5 0 R>>>>>>endobj\n4 0 obj<< /Length 67>>stream\nBT\n/F1 24 Tf\n72 120 Td\n(Hello PDF Document) Tj\nET\nendstream\nendobj\n5 0 obj<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica>>endobj\nxref\n0 6\n0000000000 65535 f\n0000000010 00000 n\n0000000060 00000 n\n0000000113 00000 n\n0000000230 00000 n\n0000000310 00000 n\ntrailer<< /Root 1 0 R /Size 6>>\nstartxref\n368\n%%EOF\n"""
+
+
+def test_extract_text_from_pdf(tmp_path: Path):
+    pdf_path = tmp_path / "sample.pdf"
+    pdf_path.write_bytes(SAMPLE_PDF)
+
+    extracted = extract_text_from_pdf(pdf_path)
+
+    assert "Hello" in extracted
+    assert "Document" in extracted

--- a/tests/test_qa.py
+++ b/tests/test_qa.py
@@ -1,0 +1,22 @@
+from pdfqanda.qa import PdfQaEngine
+from pdfqanda.splitter import TextChunk
+from pdfqanda.vectorstore import TfidfVectorStore
+
+
+def test_engine_returns_answers(monkeypatch):
+    engine = PdfQaEngine()
+
+    # Patch store to avoid PDF I/O and chunking
+    chunks = [
+        TextChunk(content="Python is a programming language.", index=0, start_char=0, end_char=35),
+        TextChunk(content="It is popular for data science.", index=1, start_char=36, end_char=68),
+    ]
+
+    store = TfidfVectorStore()
+    store.fit(chunks)
+    engine.store = store
+
+    answers = engine.query("What is Python?")
+
+    assert answers
+    assert "programming" in answers[0].text.lower()

--- a/tests/test_splitter.py
+++ b/tests/test_splitter.py
@@ -1,0 +1,13 @@
+from pdfqanda.splitter import TextSplitter
+
+
+def test_splitter_respects_overlap():
+    text = "abcdefghijklmnopqrstuvwxyz"
+    splitter = TextSplitter(chunk_size=10, overlap=2)
+    chunks = splitter.split_text(text)
+
+    assert len(chunks) == 3
+    assert chunks[0].content == "abcdefghij"
+    assert chunks[1].content.startswith("ijklmnop")
+    assert chunks[1].start_char == 8
+    assert chunks[1].end_char == 18

--- a/tests/test_vectorstore.py
+++ b/tests/test_vectorstore.py
@@ -1,0 +1,19 @@
+from pdfqanda.splitter import TextChunk
+from pdfqanda.vectorstore import TfidfVectorStore
+
+
+def test_vectorstore_query_returns_ranked_results():
+    chunks = [
+        TextChunk(content="The sky is blue and clear.", index=0, start_char=0, end_char=25),
+        TextChunk(content="Grass is green and lush.", index=1, start_char=26, end_char=48),
+        TextChunk(content="Roses are red and violets are blue.", index=2, start_char=49, end_char=86),
+    ]
+
+    store = TfidfVectorStore()
+    store.fit(chunks)
+
+    results = store.query("What color is the sky?", top_k=2)
+
+    assert len(results) == 2
+    assert results[0].chunk.index == 0
+    assert results[0].score >= results[1].score


### PR DESCRIPTION
## Summary
- scaffold a pdf question answering package with ingestion, text splitting, vector storage, and query orchestration modules
- add a Typer-powered CLI for building indexes from PDFs and querying for relevant excerpts
- configure project metadata, documentation, and unit tests covering ingestion, chunking, vector search, and engine behavior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5ad9f3c6483318696a6f1457dec59