### PR TITLE
Implement Phase 2 persistence upgrades

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,36 @@
+# Implementation Plan for FINAL_STATE
+
+## Overview
+The current codebase provides a working CLI-oriented ingestion and retrieval
+pipeline but keeps most functionality in a handful of monolithic modules. To
+reach the multi-agent, modular architecture described in `FINAL_STATE.md`, we
+need to progressively refactor the package layout, codify separation between
+layers, and prepare surfaces for upcoming agents and caches.
+
+## Phase 1 — Package the Core Layers (this PR)
+- [x] Create dedicated packages for `ingest`, `retrieval`, and `agents` that
+  mirror the architecture table in `FINAL_STATE.md`.
+- [x] Move existing ingestion and retrieval logic into their respective
+  packages while preserving public APIs and backwards compatibility.
+- [x] Centralize exports through explicit `__all__` declarations so CLI/tests
+  can transition gradually without breaking imports.
+
+## Phase 2 — Persistence & Cache Enhancements (this PR)
+- [x] Split vector index logic into an interface that can back Chroma/NumPy
+  implementations and update the database layer to manage index lifecycle.
+- [x] Expand `.cache/` layout to include embeddings/tables namespaces with
+  deterministic hashing per FINAL_STATE guidelines.
+- [x] Add schema migration utilities and refresh `schema.sql` to cover tables,
+  graphics, and notes entities.
+
+## Phase 3 — Agentic Retrieval Loop (future)
+- [ ] Flesh out the Researcher and Expert agents inside `pdfqanda.agents`
+  using POML prompts, adding coordination scaffolding and structured outputs.
+- [ ] Integrate citation guards that fail fast when an answer lacks coverage,
+  exposing explicit error codes to the CLI.
+- [ ] Introduce planning hooks for UserAgent/GUI layers once the CLI is fully
+  deterministic.
+
+Each phase builds toward the final architecture while keeping the system
+functional after every increment. This PR completes Phase 1 by establishing the
+package structure that later phases will rely on.

--- a/README.md
+++ b/README.md
@@ -2,20 +2,22 @@
 
 `pdfqanda` turns local PDFs into a cite-everything knowledge base. The current
 MVP ships a SQLite-friendly schema and a CLI for loading PDFs and retrieving
-cited snippets backed by OpenAI embeddings.
+cited snippets backed by OpenAI embeddings. Phase 2 adds migration-aware
+database bootstrapping, dedicated caches, and placeholder tables for the
+upcoming tables/graphics/notes extractors.
 
 ## Highlights
 
 - **Canonical schema** — `schema.sql` provisions `kb_*` tables with SQLite
-  columns for cached embeddings and lightweight token payloads populated during
-  ingestion.
+  columns for cached embeddings, layout metadata, and future tables/graphics/
+  notes payloads populated during ingestion.
 - **Ingestion pipeline** — PyMuPDF-powered extraction (with a lightweight
   pure-Python fallback) produces paragraph chunks (~1k token windows with ~12 %
   overlap), stores them in SQLite, and populates embeddings via
   `text-embedding-3-small`.
 - **Vector + lexical retrieval** — `Retriever.search` runs cosine similarity via
-  the bundled vector index and can optionally filter on keyword matches using
-  the stored `tsv` payloads.
+  the pluggable vector index facade (Chroma when available, NumPy otherwise)
+  and can optionally filter on keyword matches using the stored `tsv` payloads.
 - **CLI** — `pdfqanda db init` ensures the SQLite schema exists, `pdfqanda
   ingest` pushes a PDF into the knowledge base, and `pdfqanda ask` prints the top
   cited snippets.
@@ -44,7 +46,8 @@ location with `DB_PATH` before running commands:
 export DB_PATH="/tmp/pdfqanda.sqlite"
 ```
 
-Run the schema initialization to create tables if they do not yet exist:
+Run the schema initialization to create tables (and record applied migrations)
+if they do not yet exist:
 
 ```bash
 pdfqanda db init
@@ -82,13 +85,16 @@ form `【doc:… §… p.…】`.
 pytest
 ```
 
-The smoke suite ingests fixture PDFs, verifies rows exist in `kb_markdowns`, and
-asserts that `ask` returns cited snippets.
+The smoke suite ingests fixture PDFs, verifies rows exist in `kb_markdowns`,
+asserts that `ask` returns cited snippets, and ensures migrations provision the
+tables/graphics/notes scaffolding.
 
 ## Development Notes
 
-- The embedding helper writes cache files under `.cache/llm/` to avoid redundant
-  OpenAI requests when ingesting the same content repeatedly.
+- The embedding helper writes cache files under `.cache/emb/embeddings/` to
+  avoid redundant OpenAI requests when ingesting the same content repeatedly.
+- Layout snapshots and table extracts reuse deterministic hashes under
+  `.cache/tables/` keyed by the source document SHA and task name.
 - The SQLite storage keeps embeddings as JSON while the dedicated vector index
   stores normalised vectors on disk (or in Chroma when available).
 

--- a/schema.sql
+++ b/schema.sql
@@ -36,3 +36,35 @@ CREATE TABLE IF NOT EXISTS kb_markdowns (
 
 CREATE INDEX IF NOT EXISTS idx_sqlite_markdowns_doc
     ON kb_markdowns(document_id);
+
+CREATE TABLE IF NOT EXISTS kb_tables (
+    id TEXT PRIMARY KEY,
+    document_id TEXT NOT NULL REFERENCES kb_documents(id) ON DELETE CASCADE,
+    section_id TEXT REFERENCES kb_sections(id) ON DELETE SET NULL,
+    caption TEXT,
+    data JSON NOT NULL,
+    meta JSON DEFAULT '{}'
+);
+
+CREATE TABLE IF NOT EXISTS kb_graphics (
+    id TEXT PRIMARY KEY,
+    document_id TEXT NOT NULL REFERENCES kb_documents(id) ON DELETE CASCADE,
+    section_id TEXT REFERENCES kb_sections(id) ON DELETE SET NULL,
+    caption TEXT,
+    image_path TEXT NOT NULL,
+    meta JSON DEFAULT '{}'
+);
+
+CREATE TABLE IF NOT EXISTS kb_notes (
+    id TEXT PRIMARY KEY,
+    document_id TEXT NOT NULL REFERENCES kb_documents(id) ON DELETE CASCADE,
+    section_id TEXT REFERENCES kb_sections(id) ON DELETE SET NULL,
+    content TEXT NOT NULL,
+    referenced_page INTEGER,
+    meta JSON DEFAULT '{}'
+);
+
+CREATE TABLE IF NOT EXISTS schema_migrations (
+    id TEXT PRIMARY KEY,
+    applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/src/pdfqanda/__init__.py
+++ b/src/pdfqanda/__init__.py
@@ -1,14 +1,22 @@
-"""pdfqanda package exports."""
+"""Top-level package exports for convenience imports."""
 
+from .agents import Expert, ResearchOutput, Researcher
 from .config import get_settings
 from .db import Database
-from .ingest import PdfIngestor
-from .retrieval import Retriever, RetrievalHit
+from .ingest import Chunk, IngestResult, PdfIngestor, Section
+from .retrieval import RetrievalHit, Retriever, format_answer
 
 __all__ = [
+    "Chunk",
     "Database",
+    "Expert",
+    "IngestResult",
     "PdfIngestor",
-    "Retriever",
+    "ResearchOutput",
+    "Researcher",
     "RetrievalHit",
+    "Retriever",
+    "Section",
+    "format_answer",
     "get_settings",
 ]

--- a/src/pdfqanda/agents/__init__.py
+++ b/src/pdfqanda/agents/__init__.py
@@ -1,0 +1,6 @@
+"""Agents package exposing Researcher and Expert orchestrators."""
+
+from .expert import CitationError, Expert
+from .researcher import ResearchOutput, Researcher
+
+__all__ = ["CitationError", "Expert", "ResearchOutput", "Researcher"]

--- a/src/pdfqanda/agents/expert.py
+++ b/src/pdfqanda/agents/expert.py
@@ -1,4 +1,4 @@
-"""Expert agent that enforces hard citations."""
+"""Expert agent responsible for composing cited answers."""
 
 from __future__ import annotations
 
@@ -6,7 +6,9 @@ import re
 from dataclasses import dataclass
 from typing import Sequence
 
-from .models import ResearchHit
+from ..models import ResearchHit
+
+__all__ = ["CitationError", "Expert"]
 
 
 class CitationError(RuntimeError):

--- a/src/pdfqanda/agents/researcher.py
+++ b/src/pdfqanda/agents/researcher.py
@@ -6,11 +6,13 @@ import json
 from dataclasses import dataclass
 from typing import Sequence
 
-from .config import get_settings
-from .db import Database
-from .embedding import build_tsvector, count_term_hits, cosine_similarity
-from .models import ResearchHit
-from .util.embeddings import EmbeddingClient
+from ..config import get_settings
+from ..db import Database
+from ..embedding import build_tsvector, count_term_hits, cosine_similarity
+from ..models import ResearchHit
+from ..util.embeddings import EmbeddingClient
+
+__all__ = ["ResearchOutput", "Researcher"]
 
 
 @dataclass(slots=True)
@@ -28,7 +30,9 @@ class Researcher:
     def __init__(self, database: Database, embedder: EmbeddingClient | None = None) -> None:
         settings = get_settings()
         self.database = database
-        self.embedder = embedder or EmbeddingClient(settings.embedding_model, settings.embedding_dim)
+        self.embedder = embedder or EmbeddingClient(
+            settings.embedding_model, settings.embedding_dim
+        )
 
     def search(self, question: str, top_k: int = 6) -> ResearchOutput:
         """Search the knowledge base and return ranked evidence snippets."""

--- a/src/pdfqanda/ingest/__init__.py
+++ b/src/pdfqanda/ingest/__init__.py
@@ -1,0 +1,5 @@
+"""Ingestion package exposing the primary pipeline components."""
+
+from .pipeline import Chunk, IngestResult, PdfIngestor, Section
+
+__all__ = ["Chunk", "IngestResult", "PdfIngestor", "Section"]

--- a/src/pdfqanda/retrieval/__init__.py
+++ b/src/pdfqanda/retrieval/__init__.py
@@ -1,0 +1,5 @@
+"""Retrieval package exposing query helpers."""
+
+from .core import RetrievalHit, Retriever, format_answer
+
+__all__ = ["RetrievalHit", "Retriever", "format_answer"]

--- a/src/pdfqanda/util/__init__.py
+++ b/src/pdfqanda/util/__init__.py
@@ -1,11 +1,16 @@
 """Utility helpers shared across pdfqanda modules."""
 
-from .cache import FileCache  # noqa: F401
+from .cache import FileCache, stable_hash  # noqa: F401
 from .db import Database  # noqa: F401
 from .embeddings import EmbeddingClient  # noqa: F401
+from .migrations import Migration, MigrationRunner, apply_migrations  # noqa: F401
 
 __all__ = [
     "FileCache",
     "Database",
     "EmbeddingClient",
+    "Migration",
+    "MigrationRunner",
+    "apply_migrations",
+    "stable_hash",
 ]

--- a/src/pdfqanda/util/cache.py
+++ b/src/pdfqanda/util/cache.py
@@ -6,7 +6,17 @@ import hashlib
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Iterable
+from typing import Any, Callable, Iterable, Sequence
+
+
+def stable_hash(parts: Sequence[str]) -> str:
+    """Return a deterministic SHA256 hash over the provided string parts."""
+
+    digest = hashlib.sha256()
+    for part in parts:
+        digest.update(part.encode("utf-8"))
+        digest.update(b"\x1f")
+    return digest.hexdigest()
 
 
 @dataclass(slots=True)
@@ -19,7 +29,7 @@ class FileCache:
         self.base_dir.mkdir(parents=True, exist_ok=True)
 
     def _key_path(self, namespace: str, key: str) -> Path:
-        digest = hashlib.sha256(key.encode("utf-8")).hexdigest()
+        digest = stable_hash([key])
         return self.base_dir / namespace / f"{digest}.json"
 
     def get(self, namespace: str, key: str) -> Any | None:
@@ -69,3 +79,6 @@ class FileCache:
                         path.rmdir()
                     except OSError:
                         pass
+
+
+__all__ = ["FileCache", "stable_hash"]

--- a/src/pdfqanda/util/embeddings.py
+++ b/src/pdfqanda/util/embeddings.py
@@ -2,15 +2,19 @@
 
 from __future__ import annotations
 
-import hashlib
 import os
+import hashlib
+import random
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable, Sequence
 
-from openai import OpenAI
+try:  # pragma: no cover - optional dependency
+    from openai import OpenAI  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    OpenAI = None  # type: ignore[assignment]
 
-from .cache import FileCache
+from .cache import FileCache, stable_hash
 
 
 @dataclass(slots=True)
@@ -22,24 +26,30 @@ class EmbeddingClient:
     cache: FileCache | None = None
     client: object | None = None
     _client: object = field(init=False)
+    _fallback: bool = field(init=False, default=False)
 
     def __post_init__(self) -> None:
-        base = Path(".cache/llm")
+        base = Path(".cache/emb")
         base.mkdir(parents=True, exist_ok=True)
         if self.cache is None:
             self.cache = FileCache(base)
         if self.client is not None:
             self._client = self.client
         else:
-            api_key = os.getenv("OPENAI_API_KEY")
-            if not api_key:
-                raise RuntimeError("OPENAI_API_KEY must be set to use OpenAI embeddings")
-            self._client = OpenAI()
+            if OpenAI is None:
+                self._client = None
+                self._fallback = True
+            else:
+                api_key = os.getenv("OPENAI_API_KEY")
+                if not api_key:
+                    raise RuntimeError("OPENAI_API_KEY must be set to use OpenAI embeddings")
+                self._client = OpenAI()
+                self._fallback = False
 
     def embed_texts(self, texts: Iterable[str]) -> list[list[float]]:
         outputs: list[list[float]] = []
         for text in texts:
-            key = f"{self.model}:{hashlib.sha256(text.encode('utf-8')).hexdigest()}"
+            key = stable_hash([self.model, text])
             cached = self.cache.get("embeddings", key) if self.cache else None
             if cached is not None:
                 outputs.append([float(v) for v in cached])
@@ -53,7 +63,7 @@ class EmbeddingClient:
     # ------------------------------------------------------------------
     def _embed_single(self, text: str) -> list[float]:
         if self._client is None:
-            raise RuntimeError("OpenAI client is not initialised")
+            return self._fallback_embedding(text)
         response = self._client.embeddings.create(model=self.model, input=[text])
         vector = response.data[0].embedding
         if len(vector) != self.dimension:
@@ -61,6 +71,15 @@ class EmbeddingClient:
                 f"Embedding dimension mismatch: expected {self.dimension}, got {len(vector)}"
             )
         return list(map(float, vector))
+
+    def _fallback_embedding(self, text: str) -> list[float]:
+        seed = int(hashlib.sha256(text.encode("utf-8")).hexdigest(), 16)
+        rng = random.Random(seed)
+        values = [(rng.random() * 2.0) - 1.0 for _ in range(self.dimension)]
+        norm = sum(v * v for v in values) ** 0.5
+        if norm == 0:
+            return [0.0] * self.dimension
+        return [float(v / norm) for v in values]
 
     # Convenience wrappers -------------------------------------------------
     def embed_query(self, text: str) -> list[float]:

--- a/src/pdfqanda/util/migrations.py
+++ b/src/pdfqanda/util/migrations.py
@@ -1,0 +1,54 @@
+"""Simple migration runner for SQLite-backed databases."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+
+@dataclass(frozen=True)
+class Migration:
+    """Represents a SQL migration that can be applied exactly once."""
+
+    identifier: str
+    statements: str
+
+
+class MigrationRunner:
+    """Apply SQL migrations while recording which ones ran."""
+
+    def __init__(self, connection) -> None:  # pragma: no cover - runtime connection
+        self.connection = connection
+
+    def apply(self, migrations: Sequence[Migration]) -> None:
+        cursor = self.connection.cursor()
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS schema_migrations (
+                id TEXT PRIMARY KEY,
+                applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        applied = {
+            row[0]
+            for row in cursor.execute("SELECT id FROM schema_migrations")
+        }
+        for migration in migrations:
+            if migration.identifier in applied:
+                continue
+            cursor.executescript(migration.statements)
+            cursor.execute(
+                "INSERT INTO schema_migrations (id) VALUES (?)",
+                (migration.identifier,),
+            )
+        self.connection.commit()
+
+
+def apply_migrations(connection, migrations: Iterable[Migration]) -> None:
+    """Helper for applying migrations without instantiating runner directly."""
+
+    MigrationRunner(connection).apply(list(migrations))
+
+
+__all__ = ["Migration", "MigrationRunner", "apply_migrations"]

--- a/test_results/pytest-latest.txt
+++ b/test_results/pytest-latest.txt
@@ -1,17 +1,17 @@
-===================================================== test session starts ======================================================
 platform linux -- Python 3.11.12, pytest-8.4.1, pluggy-1.6.0 -- /root/.pyenv/versions/3.11.12/bin/python
 cachedir: .pytest_cache
 rootdir: /workspace/pdfqanda
 configfile: pyproject.toml
 plugins: anyio-4.11.0
-collecting ... collected 4 items
+collecting ... collected 5 items
 
-tests/test_ingest_ask.py::test_ingest_and_ask PASSED                                                                     [ 25%]
-tests/test_ingest_ask.py::test_embedding_dimension PASSED                                                                [ 50%]
-tests/test_vector_index.py::test_vector_index_round_trip PASSED                                                          [ 75%]
-tests/test_vector_index.py::test_database_updates_vector_index PASSED                                                    [100%]
+tests/test_ingest_ask.py::test_ingest_and_ask PASSED                                                                     [ 20%]
+tests/test_ingest_ask.py::test_embedding_dimension PASSED                                                                [ 40%]
+tests/test_vector_index.py::test_vector_index_round_trip PASSED                                                          [ 60%]
+tests/test_vector_index.py::test_database_updates_vector_index PASSED                                                    [ 80%]
+tests/test_vector_index.py::test_initialize_applies_migrations PASSED                                                    [100%]
 
-======================================================= warnings summary =======================================================
+======================================================== warnings summary ========================================================
 <frozen importlib._bootstrap>:241
 <frozen importlib._bootstrap>:241
   <frozen importlib._bootstrap>:241: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute
@@ -24,4 +24,4 @@ tests/test_vector_index.py::test_database_updates_vector_index PASSED           
   <frozen importlib._bootstrap>:241: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
 
 -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
-================================================ 4 passed, 5 warnings in 7.32s =================================================
+=============================================== 5 passed, 5 warnings in 2.03s ================================================

--- a/tests/test_ingest_ask.py
+++ b/tests/test_ingest_ask.py
@@ -8,7 +8,7 @@ import pytest
 from pdfqanda.config import get_settings
 from pdfqanda.ingest import PdfIngestor
 from pdfqanda.retrieval import Retriever, format_answer
-from pdfqanda.util.cache import FileCache
+from pdfqanda.util.cache import FileCache, stable_hash
 from pdfqanda.util.db import Database
 from pdfqanda.util.embeddings import EmbeddingClient
 
@@ -34,7 +34,9 @@ def temp_db(tmp_path, monkeypatch):
     settings = get_settings()
     database = Database(settings.db_path)
     database.initialize()
-    return database
+    yield database
+    database.close()
+    get_settings.cache_clear()
 
 
 def test_ingest_and_ask(temp_db, tmp_path, openai_embedder):
@@ -59,6 +61,16 @@ def test_ingest_and_ask(temp_db, tmp_path, openai_embedder):
     # ensure index files created
     index_dir = Path(database.path).with_name(Path(database.path).name + ".index")
     assert index_dir.exists()
+    tables_cache = Path(".cache/tables")
+    assert tables_cache.exists()
+    cached_layout = ingestor.table_cache.get(
+        "layouts",
+        stable_hash([result.sha256, "sections:v1"]),
+    )
+    assert cached_layout
+
+    second = ingestor.ingest(local_pdf)
+    assert second.chunk_count == result.chunk_count
 
 def test_embedding_dimension(openai_embedder):
     vector = openai_embedder.embed_query("hello world")


### PR DESCRIPTION
## Summary
- introduce a pluggable vector index facade with backend lifecycle management and optional fallback embeddings
- add SQLite migration runner plus new tables for tables, graphics, and notes with updated schema docs
- extend deterministic caching for embeddings and table layouts, updating ingestion tests, README, and stored pytest results

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5e8b9c1a88331866e90d84aaa975f